### PR TITLE
Josh recipe search fix bug

### DIFF
--- a/src/recipeDatabase.cpp
+++ b/src/recipeDatabase.cpp
@@ -62,7 +62,7 @@ std::vector<Recipe> RecipeDatabase::getRecipesBySearch(const std::vector<std::st
     for (size_t i = 0; i < ingredients.size(); i++) {
         query += "ingredients.name LIKE ?";
         if (i != ingredients.size() - 1) {
-            query += " OR ";
+            query += " AND ";
         }
     }
     

--- a/src/recipeDatabase.cpp
+++ b/src/recipeDatabase.cpp
@@ -55,8 +55,14 @@ std::vector<Recipe> RecipeDatabase::getRecipesBySearch(const std::vector<std::st
         return result; 
     }
 
-    std::string baseQuery = "SELECT recipes.recipeId, recipes.recipeName, recipes.authorId, recipes.cookTime, recipes.prepTime, recipes.totalTime, recipes.datePublished, recipes.description, recipes.category, recipes.calories, recipes.servings, recipes.yieldQuantity, recipes.instructions FROM recipes JOIN recipe_ingredients ON recipes.recipeId = recipe_ingredients.recipeId JOIN ingredients ON recipe_ingredients.ingredientId = ingredients.ingredientId WHERE ";
-    std::string havingClause = " GROUP BY recipes.recipeId HAVING ";
+    std::string baseQuery = 
+        "SELECT recipes.* "
+        "FROM recipes "
+        "JOIN recipe_ingredients ON recipes.recipeId = recipe_ingredients.recipeId "
+        "JOIN ingredients ON recipe_ingredients.ingredientId = ingredients.ingredientId "
+        "WHERE recipes.recipeId IN (SELECT DISTINCT recipeId FROM images) AND (";
+
+    std::string havingClause = ") GROUP BY recipes.recipeId HAVING ";
 
     for (size_t i = 0; i < ingredients.size(); ++i) {
         baseQuery += "ingredients.name LIKE '%" + ingredients[i] + "%' ";


### PR DESCRIPTION
updated the query that returns recipes given a vector of ingredients

- now returns recipes that contain ALL of the ingredients in the vector rather at least one
- also now sorts recipes by 'datePublished' attribute so that most recent recipes are shown first
- computational time has increased, might need to consider a loading/progress visual